### PR TITLE
chore: add CODEOWNERS for reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @opensource-construction/devops

--- a/locals.tf
+++ b/locals.tf
@@ -27,6 +27,8 @@ locals {
       visibility = "public"
       has_issues = true
       teams      = { "devops" : "maintain" }
+
+      required_approving_review_count = 1
     }
 
     "osc-terraform-cloudflare-dns" = {

--- a/locals.tf
+++ b/locals.tf
@@ -97,7 +97,7 @@ locals {
       visibility      = "public"
       has_issues      = true
       has_discussions = true
-      has_projects    = true
+      has_projects    = false
 
       teams = { "web" : "push", "directory-moderators" : "triage" }
 

--- a/locals.tf
+++ b/locals.tf
@@ -28,7 +28,9 @@ locals {
       has_issues = true
       teams      = { "devops" : "maintain" }
 
+      has_branch_protection           = true
       required_approving_review_count = 1
+      required_status_checks_contexts = ["Terraform Cloud"]
     }
 
     "osc-terraform-cloudflare-dns" = {


### PR DESCRIPTION
To allow better branch protection rules this adds a CODEWONER file leveraging @opensource-construction/devops.